### PR TITLE
Make it compatible with newer versions of git

### DIFF
--- a/src/main/groovy/com/madvay/tools/build/gitbuildinfo/BuildStampTask.groovy
+++ b/src/main/groovy/com/madvay/tools/build/gitbuildinfo/BuildStampTask.groovy
@@ -58,7 +58,7 @@ class BuildStampTask extends DefaultTask {
             setStandardOutput stdout
         }
         r.assertNormalExitValue()
-        return stdout.toString().contains('nothing to commit, working directory clean')
+        return stdout.toString() ==~ /nothing to commit, working (directory|tree) clean/
     }
 
     @Input


### PR DESCRIPTION
A more robust solution is to use `git status -s`, if there is no output the repo is clean.